### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/commands/snippet.ts
+++ b/src/commands/snippet.ts
@@ -67,7 +67,7 @@ export default new Command('snippet', async (caller, cmd, _log, config) => {
 				return caller.utils.discord.createMessage(cmd.channel.id, 'No snippets found.');
 
 			for (const name of Object.keys(snippetsRAW))
-				list.push(`${name} | ${snippetsRAW[name].content.length > 50 ? snippetsRAW[name].content.substr(0, 50) + '...' : snippetsRAW[name].content}`);
+				list.push(`${name} | ${snippetsRAW[name].content.length > 50 ? snippetsRAW[name].content.slice(0, 50) + '...' : snippetsRAW[name].content}`);
 
 			while (list.length > 0)
 				snippets.push(list.splice(0, s));


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.